### PR TITLE
fix: access introspection data in get-schema

### DIFF
--- a/src/cmds/get-schema.ts
+++ b/src/cmds/get-schema.ts
@@ -213,7 +213,7 @@ async function updateSingleProjectEndpoint(
 
     // Do not save an invalid schema
     const clientSchema = argv.json
-      ? buildClientSchema(newSchemaResult)
+      ? buildClientSchema(newSchemaResult.data)
       : newSchemaResult
     const errors = validateSchema(clientSchema)
     if (errors.length > 0) {


### PR DESCRIPTION
`GraphQLEndpoint.resolveIntrospection()` returns a full graphql response, so we have to pluck the `data` property off before passing it to `buildClientSchema` (which will then access the `__schema` property.)

To reproduce the error:
```sh
$ npm -g install graphql-cli@2.16.7
$ graphql get-schema -j -o full-schema.json -e http://localhost:4000/graphql
⚠ Cannot read property 'types' of undefined
```

As more proof that this is correct, `GraphQLEndpoint.resolveSchema` actually does the same thing: https://github.com/prisma/graphql-config/blob/master/src/extensions/endpoints/EndpointsExtension.ts#L145