### PR TITLE
fix: re-enable update-notifier

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,14 +19,14 @@ import {
   ConfigNotFoundError,
   resolveEnvsInValues,
 } from 'graphql-config'
-// import * as updateNotifier from 'update-notifier'
-// const pkg = require('../package.json')
+import * as updateNotifier from 'update-notifier'
+const pkg = require('../package.json')
 import 'source-map-support/register'
 
 export * from './types'
 export * from './utils'
 
-// updateNotifier({ pkg }).notify()
+updateNotifier({ pkg }).notify()
 
 function listPluggings(dir: string): string[] {
   return readdirSync(dir)


### PR DESCRIPTION
Disabled in [this commit](https://github.com/graphql-cli/graphql-cli/commit/39d5ba421b451cd76dfb0c81b630d1dadecb0cd3#diff-f41e9d04a45c83f3b6f6e630f10117feR29) without a clear reason why. I figured we probably want to have this enabled.