### PR TITLE
fix: Generate command hangs continously

### DIFF
--- a/packages/commands/generate/src/index.ts
+++ b/packages/commands/generate/src/index.ts
@@ -166,18 +166,18 @@ export const plugin: CliPlugin = {
             generateConfig.graphqlCRUD
           );
 
-          const jobs: Promise<void>[] = [];
-          if (db) {
-            jobs.push(createDatabase(backendCreator, generateConfig));
-          }
+     
           if (backend) {
-            jobs.push(createBackend(backendCreator, generateConfig));
+            await createBackend(backendCreator, generateConfig);
           }
           if (client) {
-            jobs.push(createClient(backendCreator, generateConfig));
+            await createClient(backendCreator, generateConfig);
+          }
+          if (db) {
+            await createDatabase(backendCreator, generateConfig);
           }
 
-          await Promise.all(jobs);
+          process.exit(0);
         } catch (e) {
           reportError(e);
         }


### PR DESCRIPTION
## Motivation
Fixing couple issues in one commit.

- Loggs are printed in random fassion
- Order of the commands is wrong - generate can fail means that there is no sense to migrate database (it has serious impact)
- DB command hangs as there is still maintaining db connection.