### PR TITLE
fix: Add configuration validation for generate command

### DIFF
--- a/packages/commands/generate/src/index.ts
+++ b/packages/commands/generate/src/index.ts
@@ -155,10 +155,6 @@ export const plugin: CliPlugin = {
             throw new Error(`'generate' config missing 'folders' section that is required`);
           }
           
-          if (!generateConfig.graphqlCRUD) {
-            throw new Error(`'generate' config missing 'graphqlCRUD' section that is required`);
-          }
-          
           if (!db && !client) {
             backend = true;
           }

--- a/packages/commands/generate/src/index.ts
+++ b/packages/commands/generate/src/index.ts
@@ -147,9 +147,20 @@ export const plugin: CliPlugin = {
           });
           const generateConfig: GenerateConfig = await config.extension('generate');
 
-          if (!generateConfig) {
+          if (!generateConfig && generateConfig.folders) {
             throw new Error(`You should provide a valid 'generate' config to generate schema from data model`);
           }
+          
+          if (!generateConfig.folders) {
+            throw new Error(`'generate' config missing 'folders' section that is required`);
+          }
+          
+          if (!generateConfig.graphqlCRUD) {
+            throw new Error(`'generate' config missing 'graphqlCRUD' section that is required`);
+          }
+          
+
+
 
           if (!db && !client) {
             backend = true;

--- a/packages/commands/generate/src/index.ts
+++ b/packages/commands/generate/src/index.ts
@@ -147,7 +147,7 @@ export const plugin: CliPlugin = {
           });
           const generateConfig: GenerateConfig = await config.extension('generate');
 
-          if (!generateConfig && generateConfig.folders) {
+          if (!generateConfig) {
             throw new Error(`You should provide a valid 'generate' config to generate schema from data model`);
           }
           
@@ -159,9 +159,6 @@ export const plugin: CliPlugin = {
             throw new Error(`'generate' config missing 'graphqlCRUD' section that is required`);
           }
           
-
-
-
           if (!db && !client) {
             backend = true;
           }


### PR DESCRIPTION
## Motivation

Mapping GraphlQL-Config issue - it will return a valid object that represents the entire object under some circumstances. 
Even with valid config present. We should start with validating config to see if that is happening frequently.