### PR TITLE
chore: Improve renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":pinVersions"
+  ],
+  "groupName":"all",
+  "packageRules": [
+    {
+      "packageNames": ["graphql"],
+      "versionStrategy": "widen"
+    }
   ]
 }


### PR DESCRIPTION
## Motivation

Limit number of the PR created by renovate to just couple a day thanks to selective grouping to major/minor versions. Use pinned dependencies. Do not update the graphql package to the last when it is as transitive dependency.