### PR TITLE
fix: make default value compatible existing templates

### DIFF
--- a/packages/commands/init/src/index.ts
+++ b/packages/commands/init/src/index.ts
@@ -142,7 +142,7 @@ export const plugin: CliPlugin = {
                                 type: 'input',
                                 name: 'model',
                                 message: 'Where are you going to store your data models?',
-                                default: './models'
+                                default: './model'
                             },
                             {
                                 type: 'input',


### PR DESCRIPTION
…plates

# Motivation

Migrating to graphql cli will be very simple by using graphql init. 
However, default values for model is not reflecting default one used in the template.
This simple change will reduce a lots of confusion in the community