### PR TITLE
chore(deps): remove stub type definition

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "@types/inquirer": "6.5.0",
     "@types/node": "12.12.22",
-    "@types/resolve-from": "5.0.1",
     "graphql": "14.5.8",
     "ts-node": "8.5.4",
     "typescript": "3.7.4"


### PR DESCRIPTION
`resolve-from` is shipped with in-house type definitions.