### PR TITLE
fix: Add basic integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,3 @@ typings/
 .next
 
 package-lock.json
-integration/tests/**.js

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ typings/
 .next
 
 package-lock.json
+integration/tests/**.js

--- a/integration/package.json
+++ b/integration/package.json
@@ -34,4 +34,4 @@
       "ts-node/register"
     ]
   }
-
+}

--- a/integration/package.json
+++ b/integration/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc tests/**",
+
     "test": "ava"
   },
   "dependencies": {
@@ -34,4 +34,4 @@
       "ts-node/register"
     ]
   }
-}
+

--- a/integration/package.json
+++ b/integration/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphql-cli-integration-testse",
+  "name": "graphql-cli-integration-test",
   "version": "4.0.0",
   "license": "MIT",
   "private": true,

--- a/integration/package.json
+++ b/integration/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "graphql-cli-integration-testse",
+  "version": "4.0.0",
+  "license": "MIT",
+  "private": true,
+  "main": "dist/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc tests/**",
+    "test": "ava"
+  },
+  "dependencies": {
+    "log-symbols": "3.0.0",
+    "tslib": "1.10.0"
+  },
+  "devDependencies": {
+    "@types/node": "12.12.9",
+    "ava": "^2.4.0",
+    "execa": "^4.0.0",
+    "graphql": "14.5.8",
+    "typescript": "3.7.2"
+  },
+  "ava": {
+    "files": [
+      "tests/**/*"
+    ],
+    "compileEnhancements": false,
+    "extensions": [
+      "ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ]
+  }
+}

--- a/integration/tests/workflow.ts
+++ b/integration/tests/workflow.ts
@@ -1,16 +1,23 @@
 // tslint:disable-next-line: match-default-export-name no-implicit-dependencies
 import ava, { ExecutionContext } from 'ava';
 import { resolve } from 'path';
-const execa = require('execa');
+import { execSync } from 'child_process';
 
-ava('Test cli workflow', async (t: ExecutionContext) => {
+
+ava('Test cli workflow', (t: ExecutionContext) => {
   const basePath = resolve(`${__dirname}/../../templates/fullstack`);
-  process.chdir(basePath)
-    
+  console.log(`Running commands in ${basePath}`)
   try {
-    console.log(await execa('yarn', ['graphql', 'generate']));
-    console.log(await execa('yarn', ['graphql', 'codegen']));
-    console.log(await execa('yarn', ['schemats', 'generate']));
+    let generate = execSync('yarn graphql generate --backend', { encoding: 'utf8', cwd: basePath });
+    generate += execSync('yarn graphql generate --client', { encoding: 'utf8', cwd: basePath });
+    const codegen = execSync('yarn graphql codegen', { encoding: 'utf8', cwd: basePath });
+    const schemats = execSync('yarn schemats generate', { encoding: 'utf8', cwd: basePath });
+
+    console.log(`
+    Generate: ${generate}\n
+    Codegen: ${codegen}\n
+    Schemats: ${schemats}
+   `)
   } catch (error) {
     t.fail(`build failed with ${error}`);
   }

--- a/integration/tests/workflow.ts
+++ b/integration/tests/workflow.ts
@@ -1,0 +1,17 @@
+// tslint:disable-next-line: match-default-export-name no-implicit-dependencies
+import ava, { ExecutionContext } from 'ava';
+import { resolve } from 'path';
+const execa = require('execa');
+
+ava('Test cli workflow', async (t: ExecutionContext) => {
+  const basePath = resolve(`${__dirname}/../../templates/fullstack`);
+  process.chdir(basePath)
+    
+  try {
+    console.log(await execa('yarn', ['graphql', 'generate']));
+    console.log(await execa('yarn', ['graphql', 'codegen']));
+    console.log(await execa('yarn', ['schemats', 'generate']));
+  } catch (error) {
+    t.fail(`build failed with ${error}`);
+  }
+});

--- a/integration/tests/workflow.ts
+++ b/integration/tests/workflow.ts
@@ -6,16 +6,19 @@ import { execSync } from 'child_process';
 
 ava('Test cli workflow', (t: ExecutionContext) => {
   const basePath = resolve(`${__dirname}/../../templates/fullstack`);
+  process.chdir(basePath)
   console.log(`Running commands in ${basePath}`)
   try {
     let generate = execSync('yarn graphql generate --backend', { encoding: 'utf8', cwd: basePath });
     generate += execSync('yarn graphql generate --client', { encoding: 'utf8', cwd: basePath });
-    const codegen = 'disabled' // execSync('yarn graphql codegen', { encoding: 'utf8', cwd: basePath });
+    const codegen = execSync('yarn graphql codegen', { encoding: 'utf8', cwd: basePath });
 
     console.log(`
     Generate: ${generate}\n
     Codegen: ${codegen}\n
    `)
+    t.true(codegen.indexOf('error') === -1)
+    t.true(generate.indexOf('failed') === -1)
   } catch (error) {
     t.fail(`build failed with ${error}`);
   }

--- a/integration/tests/workflow.ts
+++ b/integration/tests/workflow.ts
@@ -7,11 +7,13 @@ import { execSync } from 'child_process';
 ava('Test cli workflow', (t: ExecutionContext) => {
   const basePath = resolve(`${__dirname}/../../templates/fullstack`);
   process.chdir(basePath)
+  // Workaround for github actions symlinking issue
+  const graphQLCmd = 'node ../../packages/cli/dist/index.js'
   console.log(`Running commands in ${basePath}`)
   try {
-    let generate = execSync('yarn graphql generate --backend', { encoding: 'utf8', cwd: basePath });
-    generate += execSync('yarn graphql generate --client', { encoding: 'utf8', cwd: basePath });
-    const codegen = execSync('yarn graphql codegen', { encoding: 'utf8', cwd: basePath });
+    let generate = execSync(`${graphQLCmd} generate --backend`, { encoding: 'utf8', cwd: basePath });
+    generate += execSync(`${graphQLCmd} generate --client`, { encoding: 'utf8', cwd: basePath });
+    const codegen = execSync(`${graphQLCmd} codegen`, { encoding: 'utf8', cwd: basePath });
 
     console.log(`
     Generate: ${generate}\n

--- a/integration/tests/workflow.ts
+++ b/integration/tests/workflow.ts
@@ -10,13 +10,11 @@ ava('Test cli workflow', (t: ExecutionContext) => {
   try {
     let generate = execSync('yarn graphql generate --backend', { encoding: 'utf8', cwd: basePath });
     generate += execSync('yarn graphql generate --client', { encoding: 'utf8', cwd: basePath });
-    const codegen = execSync('yarn graphql codegen', { encoding: 'utf8', cwd: basePath });
-    const schemats = execSync('yarn schemats generate', { encoding: 'utf8', cwd: basePath });
+    const codegen = 'disabled' // execSync('yarn graphql codegen', { encoding: 'utf8', cwd: basePath });
 
     console.log(`
     Generate: ${generate}\n
     Codegen: ${codegen}\n
-    Schemats: ${schemats}
    `)
   } catch (error) {
     t.fail(`build failed with ${error}`);

--- a/integration/tsconfig.json
+++ b/integration/tsconfig.json
@@ -1,0 +1,26 @@
+{
+    "compilerOptions": {
+      "skipLibCheck": true,
+      "esModuleInterop": true,
+      "importHelpers": true,
+      "experimentalDecorators": true,
+      "module": "commonjs",
+      "target": "es2018",
+      "lib": ["es6", "esnext", "es2015", "dom"],
+      "moduleResolution": "node",
+      "emitDecoratorMetadata": true,
+      "sourceMap": true,
+      "declaration": true,
+      "outDir": "./dist",
+      "rootDir": "./tests",
+      "noImplicitAny": true,
+      "noImplicitThis": true,
+      "alwaysStrict": true,
+      "noImplicitReturns": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": false
+    },
+    "files": ["src/index.ts"],
+    "exclude": ["node_modules"]
+  }
+  

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "packages": [
       "packages/*",
       "packages/commands/*",
+      "integration",
       "templates/**/*"
     ]
   },

--- a/templates/fullstack/client/src/generated-types.tsx
+++ b/templates/fullstack/client/src/generated-types.tsx
@@ -18,20 +18,17 @@ export type Comment = {
   id: Scalars['ID'],
   title: Scalars['String'],
   description: Scalars['String'],
-  note: Note,
 };
 
 export type CommentFilter = {
   id?: Maybe<Scalars['ID']>,
   title?: Maybe<Scalars['String']>,
   description?: Maybe<Scalars['String']>,
-  noteId?: Maybe<Scalars['ID']>,
 };
 
 export type CommentInput = {
   title: Scalars['String'],
   description: Scalars['String'],
-  noteId: Scalars['ID'],
 };
 
 export type Mutation = {
@@ -111,58 +108,6 @@ export type NoteFieldsFragment = (
   & Pick<Note, 'id' | 'title' | 'description'>
 );
 
-export type FindAllCommentsQueryVariables = {};
-
-
-export type FindAllCommentsQuery = (
-  { __typename?: 'Query' }
-  & { findAllComments: Array<(
-    { __typename?: 'Comment' }
-    & CommentFieldsFragment
-  )> }
-);
-
-export type FindAllNotesQueryVariables = {};
-
-
-export type FindAllNotesQuery = (
-  { __typename?: 'Query' }
-  & { findAllNotes: Array<(
-    { __typename?: 'Note' }
-    & NoteFieldsFragment
-  )> }
-);
-
-export type FindCommentsQueryVariables = {
-  id: Scalars['ID'],
-  title: Scalars['String'],
-  description: Scalars['String']
-};
-
-
-export type FindCommentsQuery = (
-  { __typename?: 'Query' }
-  & { findComments: Array<(
-    { __typename?: 'Comment' }
-    & CommentFieldsFragment
-  )> }
-);
-
-export type FindNotesQueryVariables = {
-  id: Scalars['ID'],
-  title: Scalars['String'],
-  description: Scalars['String']
-};
-
-
-export type FindNotesQuery = (
-  { __typename?: 'Query' }
-  & { findNotes: Array<(
-    { __typename?: 'Note' }
-    & NoteFieldsFragment
-  )> }
-);
-
 export type CreateCommentMutationVariables = {
   title: Scalars['String'],
   description: Scalars['String']
@@ -221,6 +166,58 @@ export type UpdateNoteMutation = (
   ) }
 );
 
+export type FindAllCommentsQueryVariables = {};
+
+
+export type FindAllCommentsQuery = (
+  { __typename?: 'Query' }
+  & { findAllComments: Array<(
+    { __typename?: 'Comment' }
+    & CommentFieldsFragment
+  )> }
+);
+
+export type FindAllNotesQueryVariables = {};
+
+
+export type FindAllNotesQuery = (
+  { __typename?: 'Query' }
+  & { findAllNotes: Array<(
+    { __typename?: 'Note' }
+    & NoteFieldsFragment
+  )> }
+);
+
+export type FindCommentsQueryVariables = {
+  id: Scalars['ID'],
+  title: Scalars['String'],
+  description: Scalars['String']
+};
+
+
+export type FindCommentsQuery = (
+  { __typename?: 'Query' }
+  & { findComments: Array<(
+    { __typename?: 'Comment' }
+    & CommentFieldsFragment
+  )> }
+);
+
+export type FindNotesQueryVariables = {
+  id: Scalars['ID'],
+  title: Scalars['String'],
+  description: Scalars['String']
+};
+
+
+export type FindNotesQuery = (
+  { __typename?: 'Query' }
+  & { findNotes: Array<(
+    { __typename?: 'Note' }
+    & NoteFieldsFragment
+  )> }
+);
+
 export const CommentFieldsFragmentDoc = gql`
     fragment CommentFields on Comment {
   id
@@ -235,140 +232,6 @@ export const NoteFieldsFragmentDoc = gql`
   description
 }
     `;
-export const FindAllCommentsDocument = gql`
-    query findAllComments {
-  findAllComments {
-    ...CommentFields
-  }
-}
-    ${CommentFieldsFragmentDoc}`;
-
-/**
- * __useFindAllCommentsQuery__
- *
- * To run a query within a React component, call `useFindAllCommentsQuery` and pass it any options that fit your needs.
- * When your component renders, `useFindAllCommentsQuery` returns an object from Apollo Client that contains loading, error, and data properties 
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useFindAllCommentsQuery({
- *   variables: {
- *   },
- * });
- */
-export function useFindAllCommentsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<FindAllCommentsQuery, FindAllCommentsQueryVariables>) {
-        return ApolloReactHooks.useQuery<FindAllCommentsQuery, FindAllCommentsQueryVariables>(FindAllCommentsDocument, baseOptions);
-      }
-export function useFindAllCommentsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<FindAllCommentsQuery, FindAllCommentsQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<FindAllCommentsQuery, FindAllCommentsQueryVariables>(FindAllCommentsDocument, baseOptions);
-        }
-export type FindAllCommentsQueryHookResult = ReturnType<typeof useFindAllCommentsQuery>;
-export type FindAllCommentsLazyQueryHookResult = ReturnType<typeof useFindAllCommentsLazyQuery>;
-export type FindAllCommentsQueryResult = ApolloReactCommon.QueryResult<FindAllCommentsQuery, FindAllCommentsQueryVariables>;
-export const FindAllNotesDocument = gql`
-    query findAllNotes {
-  findAllNotes {
-    ...NoteFields
-  }
-}
-    ${NoteFieldsFragmentDoc}`;
-
-/**
- * __useFindAllNotesQuery__
- *
- * To run a query within a React component, call `useFindAllNotesQuery` and pass it any options that fit your needs.
- * When your component renders, `useFindAllNotesQuery` returns an object from Apollo Client that contains loading, error, and data properties 
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useFindAllNotesQuery({
- *   variables: {
- *   },
- * });
- */
-export function useFindAllNotesQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<FindAllNotesQuery, FindAllNotesQueryVariables>) {
-        return ApolloReactHooks.useQuery<FindAllNotesQuery, FindAllNotesQueryVariables>(FindAllNotesDocument, baseOptions);
-      }
-export function useFindAllNotesLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<FindAllNotesQuery, FindAllNotesQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<FindAllNotesQuery, FindAllNotesQueryVariables>(FindAllNotesDocument, baseOptions);
-        }
-export type FindAllNotesQueryHookResult = ReturnType<typeof useFindAllNotesQuery>;
-export type FindAllNotesLazyQueryHookResult = ReturnType<typeof useFindAllNotesLazyQuery>;
-export type FindAllNotesQueryResult = ApolloReactCommon.QueryResult<FindAllNotesQuery, FindAllNotesQueryVariables>;
-export const FindCommentsDocument = gql`
-    query findComments($id: ID!, $title: String!, $description: String!) {
-  findComments(fields: {id: $id, title: $title, description: $description}) {
-    ...CommentFields
-  }
-}
-    ${CommentFieldsFragmentDoc}`;
-
-/**
- * __useFindCommentsQuery__
- *
- * To run a query within a React component, call `useFindCommentsQuery` and pass it any options that fit your needs.
- * When your component renders, `useFindCommentsQuery` returns an object from Apollo Client that contains loading, error, and data properties 
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useFindCommentsQuery({
- *   variables: {
- *      id: // value for 'id'
- *      title: // value for 'title'
- *      description: // value for 'description'
- *   },
- * });
- */
-export function useFindCommentsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<FindCommentsQuery, FindCommentsQueryVariables>) {
-        return ApolloReactHooks.useQuery<FindCommentsQuery, FindCommentsQueryVariables>(FindCommentsDocument, baseOptions);
-      }
-export function useFindCommentsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<FindCommentsQuery, FindCommentsQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<FindCommentsQuery, FindCommentsQueryVariables>(FindCommentsDocument, baseOptions);
-        }
-export type FindCommentsQueryHookResult = ReturnType<typeof useFindCommentsQuery>;
-export type FindCommentsLazyQueryHookResult = ReturnType<typeof useFindCommentsLazyQuery>;
-export type FindCommentsQueryResult = ApolloReactCommon.QueryResult<FindCommentsQuery, FindCommentsQueryVariables>;
-export const FindNotesDocument = gql`
-    query findNotes($id: ID!, $title: String!, $description: String!) {
-  findNotes(fields: {id: $id, title: $title, description: $description}) {
-    ...NoteFields
-  }
-}
-    ${NoteFieldsFragmentDoc}`;
-
-/**
- * __useFindNotesQuery__
- *
- * To run a query within a React component, call `useFindNotesQuery` and pass it any options that fit your needs.
- * When your component renders, `useFindNotesQuery` returns an object from Apollo Client that contains loading, error, and data properties 
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useFindNotesQuery({
- *   variables: {
- *      id: // value for 'id'
- *      title: // value for 'title'
- *      description: // value for 'description'
- *   },
- * });
- */
-export function useFindNotesQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<FindNotesQuery, FindNotesQueryVariables>) {
-        return ApolloReactHooks.useQuery<FindNotesQuery, FindNotesQueryVariables>(FindNotesDocument, baseOptions);
-      }
-export function useFindNotesLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<FindNotesQuery, FindNotesQueryVariables>) {
-          return ApolloReactHooks.useLazyQuery<FindNotesQuery, FindNotesQueryVariables>(FindNotesDocument, baseOptions);
-        }
-export type FindNotesQueryHookResult = ReturnType<typeof useFindNotesQuery>;
-export type FindNotesLazyQueryHookResult = ReturnType<typeof useFindNotesLazyQuery>;
-export type FindNotesQueryResult = ApolloReactCommon.QueryResult<FindNotesQuery, FindNotesQueryVariables>;
 export const CreateCommentDocument = gql`
     mutation createComment($title: String!, $description: String!) {
   createComment(input: {title: $title, description: $description}) {
@@ -503,3 +366,137 @@ export function useUpdateNoteMutation(baseOptions?: ApolloReactHooks.MutationHoo
 export type UpdateNoteMutationHookResult = ReturnType<typeof useUpdateNoteMutation>;
 export type UpdateNoteMutationResult = ApolloReactCommon.MutationResult<UpdateNoteMutation>;
 export type UpdateNoteMutationOptions = ApolloReactCommon.BaseMutationOptions<UpdateNoteMutation, UpdateNoteMutationVariables>;
+export const FindAllCommentsDocument = gql`
+    query findAllComments {
+  findAllComments {
+    ...CommentFields
+  }
+}
+    ${CommentFieldsFragmentDoc}`;
+
+/**
+ * __useFindAllCommentsQuery__
+ *
+ * To run a query within a React component, call `useFindAllCommentsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFindAllCommentsQuery` returns an object from Apollo Client that contains loading, error, and data properties 
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFindAllCommentsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useFindAllCommentsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<FindAllCommentsQuery, FindAllCommentsQueryVariables>) {
+        return ApolloReactHooks.useQuery<FindAllCommentsQuery, FindAllCommentsQueryVariables>(FindAllCommentsDocument, baseOptions);
+      }
+export function useFindAllCommentsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<FindAllCommentsQuery, FindAllCommentsQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<FindAllCommentsQuery, FindAllCommentsQueryVariables>(FindAllCommentsDocument, baseOptions);
+        }
+export type FindAllCommentsQueryHookResult = ReturnType<typeof useFindAllCommentsQuery>;
+export type FindAllCommentsLazyQueryHookResult = ReturnType<typeof useFindAllCommentsLazyQuery>;
+export type FindAllCommentsQueryResult = ApolloReactCommon.QueryResult<FindAllCommentsQuery, FindAllCommentsQueryVariables>;
+export const FindAllNotesDocument = gql`
+    query findAllNotes {
+  findAllNotes {
+    ...NoteFields
+  }
+}
+    ${NoteFieldsFragmentDoc}`;
+
+/**
+ * __useFindAllNotesQuery__
+ *
+ * To run a query within a React component, call `useFindAllNotesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFindAllNotesQuery` returns an object from Apollo Client that contains loading, error, and data properties 
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFindAllNotesQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useFindAllNotesQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<FindAllNotesQuery, FindAllNotesQueryVariables>) {
+        return ApolloReactHooks.useQuery<FindAllNotesQuery, FindAllNotesQueryVariables>(FindAllNotesDocument, baseOptions);
+      }
+export function useFindAllNotesLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<FindAllNotesQuery, FindAllNotesQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<FindAllNotesQuery, FindAllNotesQueryVariables>(FindAllNotesDocument, baseOptions);
+        }
+export type FindAllNotesQueryHookResult = ReturnType<typeof useFindAllNotesQuery>;
+export type FindAllNotesLazyQueryHookResult = ReturnType<typeof useFindAllNotesLazyQuery>;
+export type FindAllNotesQueryResult = ApolloReactCommon.QueryResult<FindAllNotesQuery, FindAllNotesQueryVariables>;
+export const FindCommentsDocument = gql`
+    query findComments($id: ID!, $title: String!, $description: String!) {
+  findComments(fields: {id: $id, title: $title, description: $description}) {
+    ...CommentFields
+  }
+}
+    ${CommentFieldsFragmentDoc}`;
+
+/**
+ * __useFindCommentsQuery__
+ *
+ * To run a query within a React component, call `useFindCommentsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFindCommentsQuery` returns an object from Apollo Client that contains loading, error, and data properties 
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFindCommentsQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      title: // value for 'title'
+ *      description: // value for 'description'
+ *   },
+ * });
+ */
+export function useFindCommentsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<FindCommentsQuery, FindCommentsQueryVariables>) {
+        return ApolloReactHooks.useQuery<FindCommentsQuery, FindCommentsQueryVariables>(FindCommentsDocument, baseOptions);
+      }
+export function useFindCommentsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<FindCommentsQuery, FindCommentsQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<FindCommentsQuery, FindCommentsQueryVariables>(FindCommentsDocument, baseOptions);
+        }
+export type FindCommentsQueryHookResult = ReturnType<typeof useFindCommentsQuery>;
+export type FindCommentsLazyQueryHookResult = ReturnType<typeof useFindCommentsLazyQuery>;
+export type FindCommentsQueryResult = ApolloReactCommon.QueryResult<FindCommentsQuery, FindCommentsQueryVariables>;
+export const FindNotesDocument = gql`
+    query findNotes($id: ID!, $title: String!, $description: String!) {
+  findNotes(fields: {id: $id, title: $title, description: $description}) {
+    ...NoteFields
+  }
+}
+    ${NoteFieldsFragmentDoc}`;
+
+/**
+ * __useFindNotesQuery__
+ *
+ * To run a query within a React component, call `useFindNotesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useFindNotesQuery` returns an object from Apollo Client that contains loading, error, and data properties 
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useFindNotesQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      title: // value for 'title'
+ *      description: // value for 'description'
+ *   },
+ * });
+ */
+export function useFindNotesQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<FindNotesQuery, FindNotesQueryVariables>) {
+        return ApolloReactHooks.useQuery<FindNotesQuery, FindNotesQueryVariables>(FindNotesDocument, baseOptions);
+      }
+export function useFindNotesLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<FindNotesQuery, FindNotesQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<FindNotesQuery, FindNotesQueryVariables>(FindNotesDocument, baseOptions);
+        }
+export type FindNotesQueryHookResult = ReturnType<typeof useFindNotesQuery>;
+export type FindNotesLazyQueryHookResult = ReturnType<typeof useFindNotesLazyQuery>;
+export type FindNotesQueryResult = ApolloReactCommon.QueryResult<FindNotesQuery, FindNotesQueryVariables>;

--- a/templates/fullstack/server/src/generated-types.ts
+++ b/templates/fullstack/server/src/generated-types.ts
@@ -19,20 +19,17 @@ export type Comment = {
   id: Scalars['ID'],
   title: Scalars['String'],
   description: Scalars['String'],
-  note: Note,
 };
 
 export type CommentFilter = {
   id?: Maybe<Scalars['ID']>,
   title?: Maybe<Scalars['String']>,
   description?: Maybe<Scalars['String']>,
-  noteId?: Maybe<Scalars['ID']>,
 };
 
 export type CommentInput = {
   title: Scalars['String'],
   description: Scalars['String'],
-  noteId: Scalars['ID'],
 };
 
 export type Mutation = {
@@ -206,7 +203,6 @@ export type CommentResolvers<ContextType = GraphbackRuntimeContext, ParentType e
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>,
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType>,
-  note?: Resolver<ResolversTypes['Note'], ParentType, ContextType>,
 }>;
 
 export type MutationResolvers<ContextType = GraphbackRuntimeContext, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = ResolversObject<{

--- a/templates/fullstack/server/src/schema/generated.graphql
+++ b/templates/fullstack/server/src/schema/generated.graphql
@@ -11,7 +11,6 @@ type Comment {
   id: ID!
   title: String!
   description: String!
-  note: Note!
 }
 
 input NoteInput {
@@ -22,7 +21,6 @@ input NoteInput {
 input CommentInput {
   title: String!
   description: String!
-  noteId: ID!
 }
 
 input NoteFilter {
@@ -35,7 +33,6 @@ input CommentFilter {
     id: ID
     title: String
     description: String
-    noteId: ID
 }
 
 type Query {


### PR DESCRIPTION
Current repo settings is allowing to introduce changes that do not work quite easly. 
Renovate merges changes automatically but there are no single test to check if anything in the repository will compile and produce result. 

This change tries to evaluate on existing template to see if codegen and generate works. We can follow with graphql-inspector commands easily to have full end to end test