### PR TITLE
fix: knex typings incompatibility

### DIFF
--- a/templates/fullstack/server/src/db.ts
+++ b/templates/fullstack/server/src/db.ts
@@ -5,7 +5,9 @@ export const getConfig = async () => {
     const config = await loadConfig({
         extensions: [() => ({ name: 'dbmigrations' })]
     });
-
+    if (!config) {
+        throw new Error("Missing dbmigrations config");
+    }
     const conf = await config.getDefault().extension('dbmigrations');
 
     return conf;
@@ -20,5 +22,5 @@ export const createDB = async () => {
     // connect to db
     const db = Knex(dbmigrations)
 
-    return db
+    return db as any
 }


### PR DESCRIPTION
## Motivation

Knex is being required in various places. When having different patch versions compilation will fail due to strange approach for typings in knex. Solution is to have flexible version of knex in the app level and never pass knex typed version to the core.

Additionally added error when someone will mess up with the config