### PR TITLE
fix: update codegen fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,16 @@ schema:
 documents: ./client/src/graphql/**/*.ts
 extensions:
   codegen:
-    ./server/src/generated-types.d.ts:
-      plugins:
-        - typescript
-        - typescript-resolvers
-    ./client/src/generated-types.tsx:
-      plugins:
-        - typescript
-        - typescript-operations
-        - typescript-react-apollo
+    generates:
+      ./server/src/generated-types.d.ts:
+        plugins:
+          - typescript
+          - typescript-resolvers
+      ./client/src/generated-types.tsx:
+        plugins:
+          - typescript
+          - typescript-operations
+          - typescript-react-apollo
       config:
         withHooks: true
   generate:


### PR DESCRIPTION
- codegen requires a `generates` field or else youre going to get a error like

```
yarn run v1.22.4
$ node_modules/graphql-cli/dist/bin.js codegen
  ✖ Parse configuration
    → Cannot convert undefined or null to object
    Generate outputs
  Cannot convert undefined or null to object
```