### PR TITLE
ci: do not trigger canary release along on release event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
 
   publish:
     # publish to npm only when doing the release
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name != 'release' }}
     name: Publish Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Publish Canary workflow should not get triggered when a Release event is trigger. This should only happen on merge to master.

Error occurred in previous run: https://github.com/Urigo/graphql-cli/runs/1220494319?check_suite_focus=true 

This does not affect anything, the stable release was successful.