### PR TITLE
All docusaurus 'editUrl' links broken in docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -111,7 +111,7 @@ module.exports = {
           routeBasePath: '/',
           include: ['**/*.md', '**/*.mdx'],
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/urigo/graphql-cli/edit/master/website/',
+          editUrl: 'https://github.com/urigo/graphql-cli/edit/master/website/command-',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
all 'Edit this page' links in documentation are broken due to what seems to be a renaming of all documentation markdown files from: `command-${cmd}.md`
to just
`${cmd}.md`

I've fixed this by manually updating the editUrl attribute in the docusaurus config; regenerating the documentation statics is another option, lmk if you want me to do that