### PR TITLE
docs: fix header on migration doc

### DIFF
--- a/website/docs/migration.md
+++ b/website/docs/migration.md
@@ -28,7 +28,7 @@ To migrate, you will first need to update your GraphQL Configuration file to mat
 
 You can [check here](https://graphql-config.com/usage) for more information about the new structure.
 
-####Specifying schema(s):
+#### Specifying schema(s):
 
 ```yml
 schema: ./src/schema/**/*.graphql #You can have URL endpoint, Git URL and local files using globs here.


### PR DESCRIPTION
Currently the migration document renders incorrectly:

![image](https://user-images.githubusercontent.com/456140/221723102-50111a57-182a-444c-9a99-7269906f91ca.png)
